### PR TITLE
Check for table existence before dropping

### DIFF
--- a/SQLMembership-Identity-OWIN/Migrations.sql
+++ b/SQLMembership-Identity-OWIN/Migrations.sql
@@ -1,12 +1,27 @@
+IF OBJECT_ID('AspNetUserRoles', 'U') IS NOT NULL
+BEGIN
 DROP TABLE AspNetUserRoles;
+END
 
+IF OBJECT_ID('AspNetUserClaims', 'U') IS NOT NULL
+BEGIN
 DROP TABLE AspNetUserClaims;
+END
 
+IF OBJECT_ID('AspNetUserLogins', 'U') IS NOT NULL
+BEGIN
 DROP TABLE AspNetUserLogins;
+END
 
+IF OBJECT_ID('AspNetRoles', 'U') IS NOT NULL
+BEGIN
 DROP TABLE AspNetRoles;
+END
 
+IF OBJECT_ID('AspNetUsers', 'U') IS NOT NULL
+BEGIN
 DROP TABLE AspNetUsers;
+END
 
 CREATE TABLE [dbo].[AspNetUsers] (
     [Id]            NVARCHAR (128) NOT NULL,


### PR DESCRIPTION
When running the migrations.sql, it would be nice to not have the immediate drop error. This takes care of that.
