### PR TITLE
Updated discriminator for current AspNet.Identity value

### DIFF
--- a/SQLMembership-Identity-OWIN/Migrations.sql
+++ b/SQLMembership-Identity-OWIN/Migrations.sql
@@ -60,7 +60,7 @@ ApplicationId,LoweredUserName,MobileAlias,IsAnonymous,LastActivityDate,LegacyPas
 MobilePIN,Email,LoweredEmail,PasswordQuestion,PasswordAnswer,IsApproved,IsLockedOut,CreateDate,
 LastLoginDate,LastPasswordChangedDate,LastLockoutDate,FailedPasswordAttemptCount,
 FailedPasswordAnswerAttemptWindowStart,FailedPasswordAnswerAttemptCount,FailedPasswordAttemptWindowStart,Comment)
-SELECT aspnet_Users.UserId,aspnet_Users.UserName,(aspnet_Membership.Password+'|'+CAST(aspnet_Membership.PasswordFormat as varchar)+'|'+aspnet_Membership.PasswordSalt),'User',NewID(),aspnet_Users.ApplicationId,aspnet_Users.LoweredUserName,
+SELECT aspnet_Users.UserId,aspnet_Users.UserName,(aspnet_Membership.Password+'|'+CAST(aspnet_Membership.PasswordFormat as varchar)+'|'+aspnet_Membership.PasswordSalt),'ApplicationUser',NewID(),aspnet_Users.ApplicationId,aspnet_Users.LoweredUserName,
 aspnet_Users.MobileAlias,aspnet_Users.IsAnonymous,aspnet_Users.LastActivityDate,aspnet_Membership.Password,
 aspnet_Membership.MobilePIN,aspnet_Membership.Email,aspnet_Membership.LoweredEmail,aspnet_Membership.PasswordQuestion,aspnet_Membership.PasswordAnswer,
 aspnet_Membership.IsApproved,aspnet_Membership.IsLockedOut,aspnet_Membership.CreateDate,aspnet_Membership.LastLoginDate,aspnet_Membership.LastPasswordChangedDate,


### PR DESCRIPTION
I just followed the blog associated with this repo. The discriminator inserted doesn't match what sql profiler showed the library using to find a user.
